### PR TITLE
Use MemoryStat.TotalBytesUsed instead of doing a calculation

### DIFF
--- a/depot/gardenstore/garden_store.go
+++ b/depot/gardenstore/garden_store.go
@@ -126,7 +126,7 @@ func (store *GardenStore) Metrics(logger lager.Logger, containerGuids []string) 
 			if metrics.Err == nil {
 				gmetrics := metrics.Metrics
 				containerMetrics[containerGuid] = executor.ContainerMetrics{
-					MemoryUsageInBytes: gmetrics.MemoryStat.TotalRss + (gmetrics.MemoryStat.TotalCache - gmetrics.MemoryStat.TotalInactiveFile),
+					MemoryUsageInBytes: gmetrics.MemoryStat.TotalBytesUsed,
 					DiskUsageInBytes:   gmetrics.DiskStat.BytesUsed,
 					TimeSpentInCPU:     time.Duration(gmetrics.CPUStat.Usage),
 				}

--- a/depot/gardenstore/garden_store.go
+++ b/depot/gardenstore/garden_store.go
@@ -126,7 +126,7 @@ func (store *GardenStore) Metrics(logger lager.Logger, containerGuids []string) 
 			if metrics.Err == nil {
 				gmetrics := metrics.Metrics
 				containerMetrics[containerGuid] = executor.ContainerMetrics{
-					MemoryUsageInBytes: gmetrics.MemoryStat.TotalBytesUsed,
+					MemoryUsageInBytes: gmetrics.MemoryStat.TotalUsageTowardLimit,
 					DiskUsageInBytes:   gmetrics.DiskStat.BytesUsed,
 					TimeSpentInCPU:     time.Duration(gmetrics.CPUStat.Usage),
 				}

--- a/depot/gardenstore/garden_store_test.go
+++ b/depot/gardenstore/garden_store_test.go
@@ -1517,7 +1517,7 @@ var _ = Describe("GardenContainerStore", func() {
 				fakeGardenClient.BulkInfoReturns(
 					map[string]garden.ContainerInfoEntry{
 						"fake-handle-1": garden.ContainerInfoEntry{
-							Err: errors.New("oh no"),
+							Err: garden.NewError("oh no"),
 						},
 						"fake-handle-2": garden.ContainerInfoEntry{
 							Info: garden.ContainerInfo{
@@ -2212,7 +2212,7 @@ var _ = Describe("GardenContainerStore", func() {
 			BeforeEach(func() {
 				fakeGardenClient.BulkMetricsReturns(map[string]garden.ContainerMetricsEntry{
 					"some-container-handle": garden.ContainerMetricsEntry{
-						Err: errors.New("oh no"),
+						Err: garden.NewError("oh no"),
 					},
 				}, nil)
 			})

--- a/depot/gardenstore/garden_store_test.go
+++ b/depot/gardenstore/garden_store_test.go
@@ -2170,9 +2170,10 @@ var _ = Describe("GardenContainerStore", func() {
 		BeforeEach(func() {
 			containerMetrics := garden.Metrics{
 				MemoryStat: garden.ContainerMemoryStat{
-					TotalRss:          100,
-					TotalCache:        12,
-					TotalInactiveFile: 1,
+					TotalRss:          100, // ignored
+					TotalCache:        12,  // ignored
+					TotalInactiveFile: 1,   // ignored
+					TotalBytesUsed:    987,
 				},
 				DiskStat: garden.ContainerDiskStat{
 					BytesUsed:  222,
@@ -2201,7 +2202,7 @@ var _ = Describe("GardenContainerStore", func() {
 			Expect(fakeGardenClient.BulkMetricsCallCount()).To(Equal(1))
 			Expect(metrics).To(HaveLen(1))
 			Expect(metrics["some-container-handle"]).To(Equal(executor.ContainerMetrics{
-				MemoryUsageInBytes: 111,
+				MemoryUsageInBytes: 987,
 				DiskUsageInBytes:   222,
 				TimeSpentInCPU:     123,
 			}))

--- a/depot/gardenstore/garden_store_test.go
+++ b/depot/gardenstore/garden_store_test.go
@@ -2170,10 +2170,10 @@ var _ = Describe("GardenContainerStore", func() {
 		BeforeEach(func() {
 			containerMetrics := garden.Metrics{
 				MemoryStat: garden.ContainerMemoryStat{
-					TotalRss:          100, // ignored
-					TotalCache:        12,  // ignored
-					TotalInactiveFile: 1,   // ignored
-					TotalBytesUsed:    987,
+					TotalRss:              100, // ignored
+					TotalCache:            12,  // ignored
+					TotalInactiveFile:     1,   // ignored
+					TotalUsageTowardLimit: 987,
 				},
 				DiskStat: garden.ContainerDiskStat{
 					BytesUsed:  222,


### PR DESCRIPTION
MemoryStat.TotalBytesUsed is a new field added to Garden so that both Windows and Linux can do their own calculations

66f7613 is included so that tests pass against the latest Garden repo ; it is only relevant to this PR since we need to build against the latest Garden.

We also added the "ignored" comment to all the other MemoryStat fields in the test, not sure if that is right but we followed what appeared to be the pattern ; feel free to remove them.