### PR TITLE
adds AfterEach to stop the reporter

### DIFF
--- a/depot/metrics/reporter_test.go
+++ b/depot/metrics/reporter_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -59,6 +60,11 @@ var _ = Describe("Reporter", func() {
 			Interval:       reportInterval,
 			Logger:         logger,
 		})
+	})
+
+	AfterEach(func() {
+		reporter.Signal(os.Interrupt)
+		Eventually(reporter.Wait()).Should(Receive())
 	})
 
 	It("reports the current capacity on the given interval", func() {


### PR DESCRIPTION
without the after each block there is a potential that old reporters will
send their data to the same fake sender. this was discovered on windows where
it is much easier to reproduce

[#103455212]

Signed-off-by: Matthew Horan <mhoran@pivotal.io>