### PR TITLE
Improve leak detection in keyed lock test

### DIFF
--- a/depot/keyed_lock/keyed_lock_test.go
+++ b/depot/keyed_lock/keyed_lock_test.go
@@ -78,15 +78,20 @@ var _ = Describe("KeyedLock", func() {
 	Describe("Reap unused locks", func() {
 		It("does not leak", func() {
 			var beforeStats, afterStats runtime.MemStats
+
+			runtime.GC()
 			runtime.ReadMemStats(&beforeStats)
+
 			for i := 0; i < 10000; i++ {
 				k := strconv.Itoa(i)
 				lockManager.Lock(k)
 				lockManager.Unlock(k)
 			}
+
+			runtime.GC()
 			runtime.ReadMemStats(&afterStats)
 
-			Expect(math.Abs(float64(afterStats.HeapObjects - beforeStats.HeapObjects))).To(BeNumerically("<", 10000))
+			Expect(math.Abs(float64(afterStats.HeapObjects) - float64(beforeStats.HeapObjects))).To(BeNumerically("<", 10000))
 		})
 	})
 })


### PR DESCRIPTION
This will fix failing tests on windows + go1.5.1 x64
Also cast both values to float before making an unsigned subtraction.