### PR TITLE
Fix race condition in run step test

### DIFF
--- a/depot/steps/run_step_test.go
+++ b/depot/steps/run_step_test.go
@@ -379,11 +379,14 @@ var _ = Describe("RunAction", func() {
 
 			Context("when the process exits", func() {
 				It("completes the perform without having sent kill", func() {
+					Eventually(spawnedProcess.SignalCallCount).Should(Equal(1))
+
 					waitExited <- (128 + 15)
 
 					Eventually(performErr).Should(Receive(Equal(steps.ErrCancelled)))
 
 					Expect(spawnedProcess.SignalCallCount()).To(Equal(1))
+					Expect(spawnedProcess.SignalArgsForCall(0)).To(Equal(garden.SignalTerminate))
 				})
 			})
 


### PR DESCRIPTION
This small patch will fix this intermittent test failure (which happens pretty often on my env when I build diego-windows-release): 


```
------------------------------
• Failure [0.049 seconds]
RunAction
C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:450
  Cancel
  C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:449
    when cancelling after perform
    C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:428
      when the process exits
      C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:388
        completes the perform without having sent kill [It]
        C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:387

        No future change is possible.  Bailing out early after 0.032s.
        Expected
            <*steps.EmittableError | 0xc0821a0800>: {
                msg: "Exited with status 143",
                wrappedError: nil,
            }
        to equal
            <*errors.errorString | 0xc082049d70>: {s: "cancelled"}

        C:/Users/Administrator/gowp/src/github.com/cloudfoundry-incubator/executor/depot/steps/run_step_test.go:384
```

Env:
```
go version go1.5.1 windows/amd64
```